### PR TITLE
feat: Add review summary generation

### DIFF
--- a/track-chair-review-tables.py
+++ b/track-chair-review-tables.py
@@ -80,7 +80,10 @@ reviews = pd.read_csv(data_dir / "reviews.csv")
 # reorder columns to match example
 column_names = reviews.columns.tolist()
 column_names = (
-    column_names[9:11] + ["Session type", "Track"] + column_names[0:9] + column_names[11:]
+    column_names[9:11]
+    + ["Session type", "Track"]
+    + column_names[0:9]
+    + column_names[11:]
 )
 
 # %%
@@ -135,7 +138,15 @@ for track_name in _tmp_track_names:
 
 # %%
 # for review_file in output_dir.glob("review_*.csv"):
-column_names = ["Proposal ID", "Proposal title", "Session type", "Track", "Average score", "Status", "Number of reviewers"]
+column_names = [
+    "Proposal ID",
+    "Proposal title",
+    "Session type",
+    "Track",
+    "Average score",
+    "Status",
+    "Number of reviewers",
+]
 
 # for review_file in output_dir.glob("review_human_networks.csv"):
 for review_file in output_dir.glob("review_*.csv"):
@@ -157,12 +168,14 @@ for review_file in output_dir.glob("review_*.csv"):
         # here being lazy and doing so by column index
         scores = proposal_dataframe.iloc[:, 6:11]
         average_score = scores.sum(axis=1).mean()  # sum across the row and then average
-        
+
         data["Proposal ID"].append(proposal_id)
         data["Proposal title"].append(proposal_dataframe["Proposal title"].tolist()[0])
         data["Session type"].append(proposal_dataframe["Session type"].tolist()[0])
         data["Average score"].append(average_score)
-        data["Number of reviewers"].append(len(proposal_dataframe["Reviewer email"].unique()))
+        data["Number of reviewers"].append(
+            len(proposal_dataframe["Reviewer email"].unique())
+        )
 
     review_summary = pd.DataFrame.from_dict(data=data)
     # safe to use zero index as know this exists for entire dataframe
@@ -172,7 +185,9 @@ for review_file in output_dir.glob("review_*.csv"):
     # reorder columns for export
     review_summary = review_summary[column_names]
     # order by average score, but sort by "Session type" first to put talks at top
-    review_summary = review_summary.sort_values(by=["Session type", "Average score"], ascending=False)
+    review_summary = review_summary.sort_values(
+        by=["Session type", "Average score"], ascending=False
+    )
 
     file_name = review_file.name.replace("review", "review-summary")
     review_summary.to_csv(output_dir / file_name, index=False)

--- a/track-chair-review-tables.py
+++ b/track-chair-review-tables.py
@@ -84,7 +84,11 @@ column_names = (
 )
 
 # %%
-for track_name in track_names:
+# for track_name in track_names:
+# c.f. https://github.com/scipy-conference/track-chair-review-tables/issues/2
+_tmp_track_names = track_names.copy()
+_tmp_track_names.remove("General")
+for track_name in _tmp_track_names:
     print(f"Creating review table for track: {track_name}")
 
     track_review = pd.DataFrame(columns=reviews.keys())

--- a/track-chair-review-tables.py
+++ b/track-chair-review-tables.py
@@ -87,11 +87,7 @@ column_names = (
 )
 
 # %%
-# for track_name in track_names:
-# c.f. https://github.com/scipy-conference/track-chair-review-tables/issues/2
-_tmp_track_names = track_names.copy()
-_tmp_track_names.remove("General")
-for track_name in _tmp_track_names:
+for track_name in track_names:
     print(f"Creating review table for track: {track_name}")
 
     track_review = pd.DataFrame(columns=reviews.keys())

--- a/track-chair-review-tables.py
+++ b/track-chair-review-tables.py
@@ -80,7 +80,7 @@ reviews = pd.read_csv(data_dir / "reviews.csv")
 # reorder columns to match example
 column_names = reviews.columns.tolist()
 column_names = (
-    column_names[9:11] + ["Session type"] + column_names[0:9] + column_names[11:]
+    column_names[9:11] + ["Session type", "Track"] + column_names[0:9] + column_names[11:]
 )
 
 # %%
@@ -114,6 +114,7 @@ for track_name in _tmp_track_names:
         session_types += [session_type] * n_reviews
 
     track_review["Session type"] = session_types
+    track_review["Track"] = track_name
 
     # reorder columns for export
     track_review = track_review[column_names]
@@ -125,3 +126,53 @@ for track_name in _tmp_track_names:
         + ".csv"
     )
     track_review.to_csv(output_dir / file_name, index=False)
+
+# %% [markdown]
+# ## Reviews Summary
+
+# %% [markdown]
+# Now create a dashboard panel kind of table for the track chair reviewers to get a quick summary of all the reviews using the tables that were just generated.
+
+# %%
+# for review_file in output_dir.glob("review_*.csv"):
+column_names = ["Proposal ID", "Proposal title", "Session type", "Track", "Average score", "Status", "Number of reviewers"]
+
+# for review_file in output_dir.glob("review_human_networks.csv"):
+for review_file in output_dir.glob("review_*.csv"):
+    data = {
+        "Proposal ID": [],
+        "Proposal title": [],
+        "Session type": [],
+        "Average score": [],
+        "Number of reviewers": [],
+    }
+    review = pd.read_csv(review_file)
+
+    proposal_ids = review["Proposal ID"].unique()
+    for proposal_id in proposal_ids:
+        proposal_id_selection = review["Proposal ID"] == proposal_id
+        proposal_dataframe = review[proposal_id_selection]
+
+        # Need to get all the scored review questions
+        # here being lazy and doing so by column index
+        scores = proposal_dataframe.iloc[:, 6:11]
+        average_score = scores.sum(axis=1).mean()  # sum across the row and then average
+        
+        data["Proposal ID"].append(proposal_id)
+        data["Proposal title"].append(proposal_dataframe["Proposal title"].tolist()[0])
+        data["Session type"].append(proposal_dataframe["Session type"].tolist()[0])
+        data["Average score"].append(average_score)
+        data["Number of reviewers"].append(len(proposal_dataframe["Reviewer email"].unique()))
+
+    review_summary = pd.DataFrame.from_dict(data=data)
+    # safe to use zero index as know this exists for entire dataframe
+    review_summary["Track"] = review["Track"][0]
+    review_summary["Status"] = "Submitted"
+
+    # reorder columns for export
+    review_summary = review_summary[column_names]
+    # order by average score, but sort by "Session type" first to put talks at top
+    review_summary = review_summary.sort_values(by=["Session type", "Average score"], ascending=False)
+
+    file_name = review_file.name.replace("review", "review-summary")
+    review_summary.to_csv(output_dir / file_name, index=False)


### PR DESCRIPTION
* Generate a review summary CSV from the corresponding track review output file.
   - The review summary becomes the first sheet that serves as a dashboard in the
     track chair Google sheet.